### PR TITLE
Refactor markdown rendering and app. settings injection

### DIFF
--- a/src/Site/Controllers/ReleasesController.cs
+++ b/src/Site/Controllers/ReleasesController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.OptionsModel;
 using Octokit;
 using RimDev.Releases.Models;
 using RimDev.Releases.ViewModels.Releases;
@@ -18,11 +17,11 @@ namespace Site.Controllers
         private readonly ILogger logger;
 
         public ReleasesController(
-            IOptions<AppSettings> appSettings,
+            AppSettings appSettings,
             GitHubClient gitHub,
             ILogger<ReleasesController> logger)
         {
-            this.appSettings = appSettings.Value;
+            this.appSettings = appSettings;
             this.gitHub = gitHub;
             this.logger = logger;
         }

--- a/src/Site/Startup.cs
+++ b/src/Site/Startup.cs
@@ -1,17 +1,11 @@
-
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.OptionsModel;
 using Octokit;
 using RimDev.Releases.Models;
+using System;
 
 namespace Site
 {
@@ -32,17 +26,24 @@ namespace Site
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));
-            
-            services.AddSingleton<GitHubClient>(s => {
-               var settings = s.GetService<IOptions<AppSettings>>();
+            services.AddSingleton<AppSettings>(s =>
+            {
+                var appSettings = new AppSettings();
+                Configuration.GetSection("AppSettings").Bind(appSettings);
 
-                Console.WriteLine(settings.Value.AccessToken);
+                return appSettings;
+            });
 
-                return new GitHubClient(new ProductHeaderValue(settings.Value.Company)) 
-               {
-                   Credentials = new Credentials(settings.Value.AccessToken)
-               };                
+            services.AddSingleton<GitHubClient>(s =>
+            {
+                var settings = s.GetService<AppSettings>();
+
+                Console.WriteLine(settings.AccessToken);
+
+                return new GitHubClient(new ProductHeaderValue(settings.Company))
+                {
+                    Credentials = new Credentials(settings.AccessToken)
+                };
             });
 
             services.AddLogging();
@@ -70,7 +71,7 @@ namespace Site
 
             app.UseStaticFiles();
 
-            
+
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/src/Site/Views/Releases/Index.cshtml
+++ b/src/Site/Views/Releases/Index.cshtml
@@ -12,7 +12,7 @@
                     <h3>release date : @release.CreatedAt</h3>
                     <hr/>
                     <div>
-                        <markdown>@release.Body</markdown>
+                        <markdown context="@release.FullName">@release.Body</markdown>
                     </div>
                 </div>
             </div>

--- a/src/Site/Views/Shared/_Repositories.cshtml
+++ b/src/Site/Views/Shared/_Repositories.cshtml
@@ -1,10 +1,10 @@
-@inject Microsoft.Extensions.OptionsModel.IOptions<RimDev.Releases.Models.AppSettings> AppSettings
+@inject RimDev.Releases.Models.AppSettings AppSettings
 @model RimDev.Releases.Models.GitHubRepository
 
 @functions{
     string active(RimDev.Releases.Models.GitHubRepository r)
     {
-        return AppSettings.Value.IsMatch(r.FullName, Model?.FullName) ? "active" : "";
+        return AppSettings.IsMatch(r.FullName, Model?.FullName) ? "active" : "";
     }
 
     string isAllActive()
@@ -18,7 +18,7 @@
         class="list-group-item @isAllActive()">
         All
     </a>
-@foreach (var release in AppSettings.Value.GetAllRepositories())
+@foreach (var release in AppSettings.GetAllRepositories())
 {
     <a asp-controller="releases"
         asp-action="show"


### PR DESCRIPTION
New behavior leverages both local and remote (GitHub) rendering for markdown.
Latter is called if markdown tag-helper contains context attribute referring to full-name of related repo.
App. settings injection has been updated to inject singleton directly. Previous behavior leveraged IOptions.
