### PR TITLE
Fix individual release markdown parsing

### DIFF
--- a/src/Site/Views/Releases/Show.cshtml
+++ b/src/Site/Views/Releases/Show.cshtml
@@ -29,7 +29,7 @@
         <div class="col-md-12">
           <h2 class="text-primary">@release.Description</h2>
           <div class="release-body">
-          <markdown context="@release.FullName">@release.Body</markdown>
+            @await Html.MarkdownAsync(release.FullName, release.Body)
           </div><!-- /.release-body -->
         </div><!-- /.col-md-12 -->
       </div><!-- /.row release -->


### PR DESCRIPTION
Previous behavior used deprecated tag-helper which did not render markdown.
## Old UI

![image](https://cloud.githubusercontent.com/assets/3382469/11782852/a93851a2-a241-11e5-825c-294a9b9a1775.png)
## New UI

![image](https://cloud.githubusercontent.com/assets/3382469/11782844/9f0cd338-a241-11e5-8955-a60944984094.png)
