### PR TITLE
GitHub Client Refactor

### DIFF
--- a/src/Site/Controllers/ReleasesController.cs
+++ b/src/Site/Controllers/ReleasesController.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Extensions.Logging;
-using Octokit;
+using RimDev.Releases.Infrastructure.GitHub;
 using RimDev.Releases.Models;
 using RimDev.Releases.ViewModels.Releases;
 
@@ -13,12 +13,12 @@ namespace Site.Controllers
     public class ReleasesController : Controller
     {
         private readonly AppSettings appSettings;
-        private readonly GitHubClient gitHub;
+        private readonly Client gitHub;
         private readonly ILogger logger;
 
         public ReleasesController(
             AppSettings appSettings,
-            GitHubClient gitHub,
+            Client gitHub,
             ILogger<ReleasesController> logger)
         {
             this.appSettings = appSettings;
@@ -75,9 +75,9 @@ namespace Site.Controllers
             try
             {
                 var releases = new List<ReleaseViewModel>();
-                var gitHubReleases = await gitHub.Release.GetAll(gitHubRepository.Owner, gitHubRepository.Name);
+                var gitHubReleases = await gitHub.GetReleases(gitHubRepository.Owner, gitHubRepository.Name);
 
-                foreach (var release in gitHubReleases)
+                foreach (var release in gitHubReleases.Releases)
                 {
                     releases.Add(new ReleaseViewModel(gitHubRepository, release));
                 }
@@ -95,9 +95,8 @@ namespace Site.Controllers
         {
             try
             {
-                var releases = await gitHub.Release.GetAll(gitHubRepository.Owner, gitHubRepository.Name);
-
-                return new ReleaseViewModel(gitHubRepository, releases.FirstOrDefault());
+                var release = await gitHub.GetLatestRelease(gitHubRepository.Owner, gitHubRepository.Name);
+                return new ReleaseViewModel(gitHubRepository, release);
             }
             catch (Exception ex)
             {

--- a/src/Site/Infrastructure/GitHub/Client.cs
+++ b/src/Site/Infrastructure/GitHub/Client.cs
@@ -22,16 +22,16 @@ namespace RimDev.Releases.Infrastructure.GitHub
         public async Task<ReleasesResponse> GetReleases(string owner, string repo, int page = 1, int pageSize = 10)
         {
             var url = new Uri($"{baseUrl}repos/{owner}/{repo}/releases?page={page}&per_page={pageSize}");
-            
-            Console.WriteLine(url.ToString());
-            
+                       
             using (var client = GetClient(url))
             {                
                 var result = await client.GetAsync("");                
 
                 result.EnsureSuccessStatusCode();
 
-                var response = await result.Content.ReadAsStringAsync();                
+                var response = await result.Content.ReadAsStringAsync();
+                
+                Console.WriteLine(response);                
 
                 return new ReleasesResponse
                 {

--- a/src/Site/Infrastructure/GitHub/Release.cs
+++ b/src/Site/Infrastructure/GitHub/Release.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+
+namespace RimDev.Releases.Infrastructure.GitHub
+{
+    public class ReleasesResponse
+    {
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+
+        public ReleasesResponse()
+        {
+            Releases = new List<Release>();
+        }
+
+        public IReadOnlyList<Release> Releases { get; set; }
+    }
+
+    public class Release
+    {
+        public Release() { }
+
+        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, int id, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt)
+        {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            AssetsUrl = assetsUrl;
+            UploadUrl = uploadUrl;
+            Id = id;
+            TagName = tagName;
+            TargetCommitish = targetCommitish;
+            Name = name;
+            Body = body;
+            Draft = draft;
+            Prerelease = prerelease;
+            CreatedAt = createdAt;
+            PublishedAt = publishedAt;
+        }
+
+        public Release(string uploadUrl)
+        {
+            UploadUrl = uploadUrl;
+        }
+
+        public string Url { get; protected set; }
+
+        public string HtmlUrl { get; protected set; }
+
+        public string AssetsUrl { get; protected set; }
+
+        public string UploadUrl { get; protected set; }
+
+        public int Id { get; protected set; }
+
+        public string TagName { get; protected set; }
+
+        public string TargetCommitish { get; protected set; }
+
+        public string Name { get; protected set; }
+
+        public string Body { get; protected set; }
+
+        public bool Draft { get; protected set; }
+
+        public bool Prerelease { get; protected set; }
+
+        public DateTimeOffset CreatedAt { get; protected set; }
+
+        public DateTimeOffset? PublishedAt { get; protected set; }
+
+        public Author Author { get; protected set; }
+    }
+
+    public class Author
+    {
+        public Author() { }
+
+        public Author(string login, int id, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
+        {
+            Login = login;
+            Id = id;
+            AvatarUrl = avatarUrl;
+            Url = url;
+            HtmlUrl = htmlUrl;
+            FollowersUrl = followersUrl;
+            FollowingUrl = followingUrl;
+            GistsUrl = gistsUrl;
+            Type = type;
+            StarredUrl = starredUrl;
+            SubscriptionsUrl = subscriptionsUrl;
+            OrganizationsUrl = organizationsUrl;
+            ReposUrl = reposUrl;
+            EventsUrl = eventsUrl;
+            ReceivedEventsUrl = receivedEventsUrl;
+            SiteAdmin = siteAdmin;
+        }
+
+        public string Login { get; protected set; }
+
+        public int Id { get; protected set; }
+
+        public string AvatarUrl { get; protected set; }
+
+        public string Url { get; protected set; }
+
+        public string HtmlUrl { get; protected set; }
+
+        public string FollowersUrl { get; protected set; }
+
+        public string FollowingUrl { get; protected set; }
+
+        public string GistsUrl { get; protected set; }
+
+        public string StarredUrl { get; protected set; }
+
+        public string SubscriptionsUrl { get; protected set; }
+
+        public string OrganizationsUrl { get; protected set; }
+
+        public string ReposUrl { get; protected set; }
+
+        public string EventsUrl { get; protected set; }
+
+        public string ReceivedEventsUrl { get; protected set; }
+
+        public string Type { get; protected set; }
+
+        public bool SiteAdmin { get; protected set; }
+    }
+}
+

--- a/src/Site/Infrastructure/GitHub/Release.cs
+++ b/src/Site/Infrastructure/GitHub/Release.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace RimDev.Releases.Infrastructure.GitHub
 {
@@ -44,16 +45,21 @@ namespace RimDev.Releases.Infrastructure.GitHub
 
         public string Url { get;  set; }
 
+        [JsonProperty("html_url")]
         public string HtmlUrl { get;  set; }
 
+        [JsonProperty("assets_url")]
         public string AssetsUrl { get;  set; }
 
+        [JsonProperty("upload_url")]
         public string UploadUrl { get;  set; }
 
         public int Id { get;  set; }
 
+        [JsonProperty("tag_name")]
         public string TagName { get;  set; }
 
+        [JsonProperty("target_commitish")]
         public string TargetCommitish { get;  set; }
 
         public string Name { get;  set; }
@@ -64,8 +70,10 @@ namespace RimDev.Releases.Infrastructure.GitHub
 
         public bool Prerelease { get;  set; }
 
+        [JsonProperty("created_at")]
         public DateTimeOffset CreatedAt { get;  set; }
 
+        [JsonProperty("published_at")]
         public DateTimeOffset? PublishedAt { get;  set; }
 
         public Author Author { get;  set; }
@@ -99,32 +107,44 @@ namespace RimDev.Releases.Infrastructure.GitHub
 
         public int Id { get;  set; }
 
+        [JsonProperty("avatar_url")]
         public string AvatarUrl { get;  set; }
 
         public string Url { get;  set; }
 
+        [JsonProperty("html_url")]
         public string HtmlUrl { get;  set; }
 
+        [JsonProperty("followers_url")]
         public string FollowersUrl { get;  set; }
 
+        [JsonProperty("following_url")]
         public string FollowingUrl { get;  set; }
 
+        [JsonProperty("gists_url")]
         public string GistsUrl { get;  set; }
-
+        
+        [JsonProperty("starred_url")]
         public string StarredUrl { get;  set; }
-
+        
+        [JsonProperty("subscriptions_url")]
         public string SubscriptionsUrl { get;  set; }
-
+        
+        [JsonProperty("organizations_url")]
         public string OrganizationsUrl { get;  set; }
-
+        
+        [JsonProperty("repos_url")]
         public string ReposUrl { get;  set; }
-
+        
+        [JsonProperty("events_url")]
         public string EventsUrl { get;  set; }
 
+        [JsonProperty("received_events_url")]
         public string ReceivedEventsUrl { get;  set; }
 
         public string Type { get;  set; }
 
+        [JsonProperty("site_admin")]
         public bool SiteAdmin { get;  set; }
     }
 }

--- a/src/Site/Infrastructure/GitHub/Release.cs
+++ b/src/Site/Infrastructure/GitHub/Release.cs
@@ -42,33 +42,33 @@ namespace RimDev.Releases.Infrastructure.GitHub
             UploadUrl = uploadUrl;
         }
 
-        public string Url { get; protected set; }
+        public string Url { get;  set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get;  set; }
 
-        public string AssetsUrl { get; protected set; }
+        public string AssetsUrl { get;  set; }
 
-        public string UploadUrl { get; protected set; }
+        public string UploadUrl { get;  set; }
 
-        public int Id { get; protected set; }
+        public int Id { get;  set; }
 
-        public string TagName { get; protected set; }
+        public string TagName { get;  set; }
 
-        public string TargetCommitish { get; protected set; }
+        public string TargetCommitish { get;  set; }
 
-        public string Name { get; protected set; }
+        public string Name { get;  set; }
 
-        public string Body { get; protected set; }
+        public string Body { get;  set; }
 
-        public bool Draft { get; protected set; }
+        public bool Draft { get;  set; }
 
-        public bool Prerelease { get; protected set; }
+        public bool Prerelease { get;  set; }
 
-        public DateTimeOffset CreatedAt { get; protected set; }
+        public DateTimeOffset CreatedAt { get;  set; }
 
-        public DateTimeOffset? PublishedAt { get; protected set; }
+        public DateTimeOffset? PublishedAt { get;  set; }
 
-        public Author Author { get; protected set; }
+        public Author Author { get;  set; }
     }
 
     public class Author
@@ -95,37 +95,37 @@ namespace RimDev.Releases.Infrastructure.GitHub
             SiteAdmin = siteAdmin;
         }
 
-        public string Login { get; protected set; }
+        public string Login { get;  set; }
 
-        public int Id { get; protected set; }
+        public int Id { get;  set; }
 
-        public string AvatarUrl { get; protected set; }
+        public string AvatarUrl { get;  set; }
 
-        public string Url { get; protected set; }
+        public string Url { get;  set; }
 
-        public string HtmlUrl { get; protected set; }
+        public string HtmlUrl { get;  set; }
 
-        public string FollowersUrl { get; protected set; }
+        public string FollowersUrl { get;  set; }
 
-        public string FollowingUrl { get; protected set; }
+        public string FollowingUrl { get;  set; }
 
-        public string GistsUrl { get; protected set; }
+        public string GistsUrl { get;  set; }
 
-        public string StarredUrl { get; protected set; }
+        public string StarredUrl { get;  set; }
 
-        public string SubscriptionsUrl { get; protected set; }
+        public string SubscriptionsUrl { get;  set; }
 
-        public string OrganizationsUrl { get; protected set; }
+        public string OrganizationsUrl { get;  set; }
 
-        public string ReposUrl { get; protected set; }
+        public string ReposUrl { get;  set; }
 
-        public string EventsUrl { get; protected set; }
+        public string EventsUrl { get;  set; }
 
-        public string ReceivedEventsUrl { get; protected set; }
+        public string ReceivedEventsUrl { get;  set; }
 
-        public string Type { get; protected set; }
+        public string Type { get;  set; }
 
-        public bool SiteAdmin { get; protected set; }
+        public bool SiteAdmin { get;  set; }
     }
 }
 

--- a/src/Site/Infrastructure/HtmlExtensions.cs
+++ b/src/Site/Infrastructure/HtmlExtensions.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc.Rendering;
-using Octokit;
+using RimDev.Releases.Infrastructure.GitHub;
 
 namespace RimDev.Releases.Infrastructure
 {
@@ -10,13 +10,12 @@ namespace RimDev.Releases.Infrastructure
             string context,
             string markdown)
             {
-                var client = value.ViewContext.HttpContext.ApplicationServices.GetService(typeof(GitHubClient)) as GitHubClient;
+                var client = value.ViewContext.HttpContext.ApplicationServices.GetService(typeof(Client)) as Client;
                 string html = string.Empty;
                 
                 if (!string.IsNullOrWhiteSpace(context) && !string.IsNullOrWhiteSpace(markdown))
-                {
-                    var r = new NewArbitraryMarkdown(markdown, "gfm", context);
-                    html = await client.Miscellaneous.RenderArbitraryMarkdown(r);
+                {                    
+                    html = await client.RenderMarkdown(markdown, context);
                 }
                 
                 return new HtmlString(html);

--- a/src/Site/Startup.cs
+++ b/src/Site/Startup.cs
@@ -3,9 +3,9 @@ using Microsoft.AspNet.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Octokit;
 using RimDev.Releases.Models;
 using System;
+using RimDev.Releases.Infrastructure.GitHub;
 
 namespace Site
 {
@@ -30,20 +30,13 @@ namespace Site
             {
                 var appSettings = new AppSettings();
                 Configuration.GetSection("AppSettings").Bind(appSettings);
-
                 return appSettings;
             });
 
-            services.AddSingleton<GitHubClient>(s =>
+            services.AddSingleton<Client>(s =>
             {
-                var settings = s.GetService<AppSettings>();
-
-                Console.WriteLine(settings.AccessToken);
-
-                return new GitHubClient(new ProductHeaderValue(settings.Company))
-                {
-                    Credentials = new Credentials(settings.AccessToken)
-                };
+                var settings = s.GetService<AppSettings>();                
+                return new Client(settings.AccessToken, settings.Company);                    
             });
 
             services.AddLogging();

--- a/src/Site/ViewModels/Releases/IndexViewModel.cs
+++ b/src/Site/ViewModels/Releases/IndexViewModel.cs
@@ -34,5 +34,7 @@ namespace RimDev.Releases.ViewModels.Releases
 
         public string Body => Release?.Body;
         public string CreatedAt => (Release != null) ? Release.CreatedAt.Date.ToShortDateString() : "n/a";
+		
+		public bool HasRelease => Release != null;
     }
 }

--- a/src/Site/ViewModels/Releases/IndexViewModel.cs
+++ b/src/Site/ViewModels/Releases/IndexViewModel.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Octokit;
+using RimDev.Releases.Infrastructure.GitHub;
 using RimDev.Releases.Models;
 
 namespace RimDev.Releases.ViewModels.Releases

--- a/src/Site/Views/Releases/Index.cshtml
+++ b/src/Site/Views/Releases/Index.cshtml
@@ -18,20 +18,22 @@
 
 <div class="row">
   @foreach(var release in Model.Releases) {
-  <div class="col-md-4 text-right release-flags">
-  <span class="btn btn-success btn-release">Release</span>
-  <div class="text-muted"><span class="fa fa-calendar"></span> @release.CreatedAt</div>
-  <img class="avatar" src="https://avatars2.githubusercontent.com/u/6231956?v=3&s=32" alt="">
-  </div><!-- /.col-md-4 -->
-  <div class="col-md-8 release-column">
-      <div class="row release">
-        <div class="col-md-12">
-          <h2 class="text-primary">@release.Description</h2>
-          <div class="release-body">
-            @await Html.MarkdownAsync(release.FullName, release.Body)
-          </div><!-- /.release-body -->
-        </div><!-- /.col-md-12 -->
-      </div><!-- /.row release -->
-  </div><!-- /.col-md-8 -->
+    if (release.HasRelease) {    
+      <div class="col-md-4 text-right release-flags">
+      <span class="btn btn-success btn-release">Release</span>
+      <div class="text-muted"><span class="fa fa-calendar"></span> @release.CreatedAt</div>
+      <img class="avatar" src="@(release.Release.Author.AvatarUrl)?v=3&s=32" alt="@(release.Release.Author.Login)" title="@(release.Release.Author.Login)">
+      </div><!-- /.col-md-4 -->
+      <div class="col-md-8 release-column">
+          <div class="row release">
+            <div class="col-md-12">
+              <h2 class="text-primary">@release.Description</h2>
+              <div class="release-body">
+                @await Html.MarkdownAsync(release.FullName, release.Body)
+              </div><!-- /.release-body -->
+            </div><!-- /.col-md-12 -->
+          </div><!-- /.row release -->
+      </div><!-- /.col-md-8 -->
+    }
   }
 </div><!-- /.row -->

--- a/src/Site/Views/Releases/Show.cshtml
+++ b/src/Site/Views/Releases/Show.cshtml
@@ -19,20 +19,22 @@
 
 <div class="row">
   @foreach(var release in Model.Releases) {
-  <div class="col-md-4 text-right release-flags">
-  <span class="btn btn-success btn-release">Release</span>
-  <div class="text-muted"><span class="fa fa-calendar"></span> @release.CreatedAt</div>
-  <img class="avatar" src="https://avatars2.githubusercontent.com/u/6231956?v=3&s=32" alt="">
-  </div><!-- /.col-md-4 -->
-  <div class="col-md-8 release-column">
-      <div class="row release">
-        <div class="col-md-12">
-          <h2 class="text-primary">@release.Description</h2>
-          <div class="release-body">
-          <markdown context="@release.FullName">@release.Body</markdown>
-          </div><!-- /.release-body -->
-        </div><!-- /.col-md-12 -->
-      </div><!-- /.row release -->
-  </div><!-- /.col-md-8 -->
+    if (release.HasRelease) {
+      <div class="col-md-4 text-right release-flags">
+      <span class="btn btn-success btn-release">Release</span>
+      <div class="text-muted"><span class="fa fa-calendar"></span> @release.CreatedAt</div>
+      <img class="avatar" src="@(release.Release.Author.AvatarUrl)?v=3&s=32" alt="@(release.Release.Author.Login)" title="@(release.Release.Author.Login)">
+      </div><!-- /.col-md-4 -->
+      <div class="col-md-8 release-column">
+          <div class="row release">
+            <div class="col-md-12">
+              <h2 class="text-primary">@release.Description</h2>
+              <div class="release-body">
+                @await Html.MarkdownAsync(release.FullName, release.Body)
+              </div><!-- /.release-body -->
+            </div><!-- /.col-md-12 -->
+          </div><!-- /.row release -->
+      </div><!-- /.col-md-8 -->
+    }
   }
 </div><!-- /.row -->

--- a/src/Site/project.json
+++ b/src/Site/project.json
@@ -21,7 +21,7 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Octokit": "0.17.0"
+    "System.Net.Http": "4.0.1-beta-23516"
   },
 
   "commands": {


### PR DESCRIPTION
Removed the `OctoKit.NET` dependency and replaced it with our own client. This keeps us from having to wait for new releases that support the functionality we need.

The GitHub client is dead, long live the new GitHub client!
