### PR TITLE
Add optional feedback logic

### DIFF
--- a/src/Site/Models/AppSettings.cs
+++ b/src/Site/Models/AppSettings.cs
@@ -32,6 +32,8 @@ namespace RimDev.Releases.Models
         {
             return fullName.Equals(current, StringComparison.InvariantCultureIgnoreCase);
         }
+
+        public bool HasEmail => !string.IsNullOrEmpty(Email);
     }
 
     public class GitHubRepository

--- a/src/Site/Views/Shared/_Header.cshtml
+++ b/src/Site/Views/Shared/_Header.cshtml
@@ -13,11 +13,14 @@
       <div class="col-md-6">
         <h4 class="text-muted"><span class="octicon octicon-repo"></span> @repository.Description</h4>
       </div>
-      <div class="col-md-6 header-email">
-          <a class="btn btn-default btn-sm" href="mailto:@AppSettings.Email">
-            <strong><span class="octicon octicon-mail"></span> Feedback? </strong>
-          </a>
-      </div>
+      @if (AppSettings.HasEmail)
+      {
+        <div class="col-md-6 header-email">
+            <a class="btn btn-default btn-sm" href="mailto:@AppSettings.Email">
+              <strong><span class="octicon octicon-mail"></span> Feedback? </strong>
+            </a>
+        </div>
+      }
     </div>
     <div class="row">
       @Html.Partial("_repositories", repository)


### PR DESCRIPTION
New behavior only shows feedback UI element if email provided via app. settings.

Previous behavior could lead to following an email-link with no `to`-address:
![image](https://cloud.githubusercontent.com/assets/3382469/11819645/f5312906-a32e-11e5-9464-d4c6bcabb0d6.png)
