### PR TITLE
Display 'Latest' rather than 'All' on tab

### DIFF
--- a/src/Site/Views/Shared/_Repositories.cshtml
+++ b/src/Site/Views/Shared/_Repositories.cshtml
@@ -18,7 +18,7 @@
         asp-controller="releases"
         asp-action="index"
         class="@isAllActive()">
-        All
+        Latest
       </a>
     </li>
 @foreach (var release in AppSettings.GetAllRepositories())


### PR DESCRIPTION
The tab that displays all of the releases together appears to display the latest release for each repository. This seems like a 'good' behavior -- however, I'm wondering if changing the tab text would make what is being displayed more clear.

![image](https://cloud.githubusercontent.com/assets/1012917/11871751/9499696a-a49f-11e5-8a0b-4ce1682e0716.png)
