### PR TITLE
Add configurable logo and company settings

### DIFF
--- a/src/Site/Infrastructure/GitHub/Client.cs
+++ b/src/Site/Infrastructure/GitHub/Client.cs
@@ -12,8 +12,9 @@ namespace RimDev.Releases.Infrastructure.GitHub
         private readonly string apiToken;
         private const string baseUrl = "https://api.github.com/";
         private readonly string userAgent;
+        public const string DefaultUserAgent = "RimDev.Releases";
 
-        public Client(string apiToken, string userAgent = "RimDev.Releases")
+        public Client(string apiToken, string userAgent = DefaultUserAgent)
         {
             this.apiToken = apiToken;
             this.userAgent = userAgent;

--- a/src/Site/Models/AppSettings.cs
+++ b/src/Site/Models/AppSettings.cs
@@ -16,6 +16,8 @@ namespace RimDev.Releases.Models
         public string AccessToken { get; set; }
         public string Email { get; set; }
         public string Logo { get; set; }
+        public bool ShowCompanyInHeader { get; set; }
+        public bool ShowLogoInHeader { get; set; }
 
         public IList<GitHubRepository> GetAllRepositories()
         {
@@ -34,6 +36,7 @@ namespace RimDev.Releases.Models
             return fullName.Equals(current, StringComparison.InvariantCultureIgnoreCase);
         }
 
+        public bool HasCompany => !string.IsNullOrEmpty(Company);
         public bool HasEmail => !string.IsNullOrEmpty(Email);
         public bool HasLogo => !string.IsNullOrEmpty(Logo);
     }

--- a/src/Site/Startup.cs
+++ b/src/Site/Startup.cs
@@ -35,8 +35,11 @@ namespace Site
 
             services.AddSingleton<Client>(s =>
             {
-                var settings = s.GetService<AppSettings>();                
-                return new Client(settings.AccessToken, settings.Company);                    
+                var settings = s.GetService<AppSettings>();
+
+                return new Client(
+                    settings.AccessToken,
+                    string.IsNullOrEmpty(settings.Company) ? Client.DefaultUserAgent : settings.Company);
             });
 
             services.AddLogging();

--- a/src/Site/Views/Shared/_Header.cshtml
+++ b/src/Site/Views/Shared/_Header.cshtml
@@ -4,13 +4,18 @@
 }
 <div class="container-fluid header-title">
   <div class="container">
-      @if (AppSettings.HasLogo)
+      @if (AppSettings.HasLogo && AppSettings.ShowLogoInHeader)
       {
         <div class="header-logo">
-          <img src="@AppSettings.Logo" alt="@AppSettings.Company">
+          <a asp-controller="releases" asp-action="index">
+            <img src="@AppSettings.Logo" alt="@AppSettings.Company">
+          </a>
         </div>
       }
-      <h1>@AppSettings.Company</h1>
+      @if (AppSettings.HasCompany && AppSettings.ShowCompanyInHeader)
+      {
+        <h1>@AppSettings.Company</h1>
+      }
   </div><!-- /.container -->
 </div><!-- /.container-fluid -->
 <header class="container-fluid">

--- a/src/Site/appsettings.json
+++ b/src/Site/appsettings.json
@@ -6,7 +6,9 @@
         "email": "",
         "repositories" : {
             /* "full repo. name": "local description of repo." */
-        }
+        },
+        "showLogoInHeader": true,
+        "showCompanyInHeader": true
     },
     "Logging": {
         "IncludeScopes": false,


### PR DESCRIPTION
New behavior allows selective-inclusion of both in the site's header.
This allows both to be included in app. settings, but not duplicate/clutter header UI.

Also includes a minor change to link back to the home screen using the header logo.
