### PR TITLE
Display Applications on dropdown

### DIFF
--- a/src/Site/Models/AppSettings.cs
+++ b/src/Site/Models/AppSettings.cs
@@ -19,6 +19,7 @@ namespace RimDev.Releases.Models
         public bool ShowCompanyInHeader { get; set; }
         public bool ShowLogoInHeader { get; set; }
         public bool UseDropdownNavigation { get; set; }
+        public string DropdownNavigationText { get; set; }
 
         public IList<GitHubRepository> GetAllRepositories()
         {

--- a/src/Site/Views/Shared/_RepositoriesDropdown.cshtml
+++ b/src/Site/Views/Shared/_RepositoriesDropdown.cshtml
@@ -18,7 +18,7 @@
   <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <strong>
         <span class="octicon octicon-list-unordered"></span>
-        Repositories 
+            @AppSettings.DropdownNavigationText
         <span class="caret"></span>
     </strong>
   </button>

--- a/src/Site/appsettings.json
+++ b/src/Site/appsettings.json
@@ -9,7 +9,8 @@
         },
         "showLogoInHeader": true,
         "showCompanyInHeader": true,
-        "useDropdownNavigation": false
+        "useDropdownNavigation": false,
+        "dropdownNavigationText": "Repositories"
     },
     "Logging": {
         "IncludeScopes": false,


### PR DESCRIPTION
On the dropdown when `useDropdownNavigation` is `true`, allow configuration of the displayed text. Users may wish to display `Applications` or something else rather than `Repositories` on the UI.

**Rationale:** An individual who is not a member of a development team may not know what a repository is.
