### PR TITLE
Update browserconfig src attributes

### DIFF
--- a/src/Site/wwwroot/browserconfig.xml
+++ b/src/Site/wwwroot/browserconfig.xml
@@ -2,10 +2,10 @@
 <browserconfig>
   <msapplication>
     <tile>
-      <square70x70logo src="~/favicons/mstile-70x70.png"/>
-      <square150x150logo src="~/favicons/mstile-150x150.png"/>
-      <square310x310logo src="~/favicons/mstile-310x310.png"/>
-      <wide310x150logo src="~/favicons/mstile-310x150.png"/>
+      <square70x70logo src="favicons/mstile-70x70.png"/>
+      <square150x150logo src="favicons/mstile-150x150.png"/>
+      <square310x310logo src="favicons/mstile-310x310.png"/>
+      <wide310x150logo src="favicons/mstile-310x150.png"/>
       <TileColor>#2d89ef</TileColor>
     </tile>
   </msapplication>


### PR DESCRIPTION
Resolves #31.

`browserconfig.xml` is being served with the `~` urls intact.

This removes the tilde. Hopefully, the lack of relying on a root path (as in, not having a `/` at the start of the `src` attributes) works here.
